### PR TITLE
Add full aurora forecast page

### DIFF
--- a/aurore.html
+++ b/aurore.html
@@ -1,39 +1,60 @@
-<section class="sujet">
-  <h2>🌌 Prévision des Aurores</h2>
-  <p id="kp-index">Chargement des données NOAA...</p>
-  <p id="kp-message"></p>
-  <p style="font-size: 0.9em; color: #777;">Données fournies par NOAA Space Weather Prediction Center</p>
-</section>
-
-<script>
-  fetch('https://services.swpc.noaa.gov/json/planetary_k_index.json')
-    .then(res => res.json())
-    .then(data => {
-      const last = data[data.length - 1];
-      const kp = parseFloat(last.kp_index);
-      const time = new Date(last.time_tag).toLocaleString('fr-CA', {
-        weekday: 'long',
-        hour: '2-digit',
-        minute: '2-digit'
-      });
-
-      document.getElementById('kp-index').innerText = `📡 Indice KP actuel : ${kp} (mesuré ${time})`;
-
-      let message = '';
-      if (kp < 3) {
-        message = "🧊 Aucune chance d'aurores à votre latitude.";
-      } else if (kp < 5) {
-        message = "✨ Faible chance d’aurores boréales dans le nord du Québec.";
-      } else if (kp >= 5 && kp < 7) {
-        message = "🌠 Probabilité élevée d’aurores dans le nord du Canada.";
-      } else if (kp >= 7) {
-        message = "🔥 Tempête géomagnétique ! Aurores possibles jusqu’au sud du Québec.";
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Prévision des Aurores</title>
+    <link rel="stylesheet" href="style.css">
+    <script>
+      const page = window.location.pathname.split("/").pop();
+      const root = "/"; // Le site est maintenant à la racine
+      if (!location.href.includes("index.html") && !location.hash) {
+          location.replace(root + "#" + page);
       }
+    </script>
+</head>
+<body>
+  <header>
+    <h1>Aurores boréales</h1>
+  </header>
+  <main>
+    <section class="sujet">
+      <h2>🌌 Prévision des Aurores</h2>
+      <p id="kp-index">Chargement des données NOAA...</p>
+      <p id="kp-message"></p>
+      <p style="font-size: 0.9em; color: #777;">Données fournies par NOAA Space Weather Prediction Center</p>
+    </section>
+  </main>
+  <script>
+    fetch('https://services.swpc.noaa.gov/json/planetary_k_index.json')
+      .then(res => res.json())
+      .then(data => {
+        const last = data[data.length - 1];
+        const kp = parseFloat(last.kp_index);
+        const time = new Date(last.time_tag).toLocaleString('fr-CA', {
+          weekday: 'long',
+          hour: '2-digit',
+          minute: '2-digit'
+        });
 
-      document.getElementById('kp-message').innerText = message;
-    })
-    .catch(err => {
-      document.getElementById('kp-index').innerText = "❌ Impossible de récupérer les données KP.";
-      console.error(err);
-    });
-</script>
+        document.getElementById('kp-index').innerText = `📡 Indice KP actuel : ${kp} (mesuré ${time})`;
+
+        let message = '';
+        if (kp < 3) {
+          message = "🧊 Aucune chance d'aurores à votre latitude.";
+        } else if (kp < 5) {
+          message = "✨ Faible chance d’aurores boréales dans le nord du Québec.";
+        } else if (kp >= 5 && kp < 7) {
+          message = "🌠 Probabilité élevée d’aurores dans le nord du Canada.";
+        } else if (kp >= 7) {
+          message = "🔥 Tempête géomagnétique ! Aurores possibles jusqu’au sud du Québec.";
+        }
+
+        document.getElementById('kp-message').innerText = message;
+      })
+      .catch(err => {
+        document.getElementById('kp-index').innerText = "❌ Impossible de récupérer les données KP.";
+        console.error(err);
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert `aurore.html` to a standalone page
- include redirect script so it works with the site's hash routing
- keep aurora forecast script fetching NOAA data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68640a7c85048326a170ed2f3d0780cf